### PR TITLE
Stride

### DIFF
--- a/src/General.ts
+++ b/src/General.ts
@@ -59,7 +59,7 @@ export class General {
     }
 
     private pack(markers: Marker[]): Float32Array {
-        if (markers.length > this.markerArray.length) {
+        if (markers.length * stride > this.markerArray.length) {
             this.markerArray = new Float32Array(markers.length * stride);
         }
 


### PR DESCRIPTION
Неправильное условие. Размер массива должен быть количество маркеров * шаг (количество данных). В демке работает потомучто маркеров сликшом дофига и условие срабатывает и выделяется память на уже новый массив правильно `markers.length * stride`