### PR TITLE
Fix transferal queue error

### DIFF
--- a/src/markerArray.ts
+++ b/src/markerArray.ts
@@ -1,13 +1,10 @@
-const members = [
-    'pixelPositionX',
-    'pixelPositionY',
-    'groupIndex',
-    'iconIndex',
-    'prevGroupIndex',
-];
+// Оффсеты должны быть пронумерованы по порядку
+export const offsets = {
+    pixelPositionX: 0,
+    pixelPositionY: 1,
+    groupIndex: 2,
+    iconIndex: 3,
+    prevGroupIndex: 4,
+};
 
-export const stride = members.length;
-export const offsets: {[key: string]: number} = members.reduce((offsets, member, index) => {
-    offsets[member] = index;
-    return offsets;
-}, {});
+export const stride = Object.keys(offsets).length;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,13 @@ export interface BBox {
     maxY: number;
 }
 
+export interface JobMessage {
+    bounds: BBox;
+    pixelRatio: number;
+    priorityGroups: PriorityGroup[];
+    sprites: Sprite[];
+}
+
 export interface WorkerMessage {
     bounds: BBox;
     pixelRatio: number;
@@ -42,7 +49,7 @@ export interface WorkerMessage {
 }
 
 export interface Job {
-    message: WorkerMessage;
+    message: JobMessage;
     markers: Marker[];
     resolve: () => void;
 }


### PR DESCRIPTION
Раньше запаковка маркеров в массив выполнялась сразу при создании `Job`, это приводило к ошибкам в тот момент, когда массив был отправлен в воркер и в главном треде был недоступен. Теперь запаковка происходит в момент перед отправкой `Job` в воркер.

Также перенес создание воркера, массива и пр. в конструктор генерала. Логика со статичными полями неочевидна и может запутать. К томе же, в этом случае нельзя создать несколько генералов так, чтобы генерализация работала параллельно.

Изменил файл `markerArray.ts`, теперь изначально хранится не массив со списком пропертей, а сразу объект. Это удобно для использования вместе с тайпскриптом, т.к. в этом случае он будет ругаться, если мы заиспользуем отсутствующую проперти.
В соседнем пулл реквесте напишу на это дело тестов, чтобы не получилось так, что у нас проперти идут не по порядку.
