### PR TITLE
Set iconIndex to markers outside bounds

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -57,15 +57,16 @@ Promise.all([
     const markers: Marker[] = [];
     for (let i = 0; i < markersData.length; i++) {
         const markerData = markersData[i];
-        const marker: any = {};
-        marker.position = [
-            markerData.lon,
-            markerData.lat,
-        ];
-        marker.groupIndex = markersData[i].is_advertising ? 0 : 1;
-        marker.mapPoint = latLngToMapPoint(marker.position);
-        marker.iconIndex = -1;
-        marker.data = markerData;
+        const position: [number, number] = [markerData.lon, markerData.lat];
+        const mapPoint = latLngToMapPoint(position);
+        const marker: Marker = {
+            position,
+            groupIndex: markersData[i].is_advertising ? 0 : 1,
+            mapPoint,
+            iconIndex: -1,
+            data: markerData,
+            pixelPosition: mapPointToZoomPoint(mapPoint, map.getZoom()),
+        };
         markers.push(marker);
     }
 
@@ -75,12 +76,7 @@ Promise.all([
 
     const retinaFactor = window.devicePixelRatio;
     const size = map.getSize();
-    const bounds: BBox = {
-        minX: -size.x * retinaFactor / 2,
-        minY: -size.y * retinaFactor / 2,
-        maxX: size.x * retinaFactor * 1.5,
-        maxY: size.y * retinaFactor * 1.5,
-    };
+    let bounds: BBox = { minX: 0, minY: 0, maxX: 0, maxY: 0 };
 
     const markerDrawer = new MarkerDrawer();
     markerDrawer.setAtlas(atlas);
@@ -91,7 +87,7 @@ Promise.all([
     });
     markerDrawer.addTo(map);
 
-    let resetLastGroupIndex = false;
+    let zoomChanged = false;
     let generalizationIsBusy = false;
     let generalizetionNeedUpdate = false;
 
@@ -99,7 +95,7 @@ Promise.all([
 
     // dat gui
     const datGuiOnchange = () => {
-        resetLastGroupIndex = true;
+        zoomChanged = true;
         updateGeneralization();
     };
     priorityGroups.forEach((group, i) => {
@@ -127,21 +123,22 @@ Promise.all([
         const center = map.getCenter();
         const zoom = map.getZoom();
         const pixelCenter = lngLatToZoomPoint([center.lng, center.lat], zoom);
-        const topLeft = [pixelCenter[0] - size.x, pixelCenter[1] - size.y];
 
-        for (let i = 0; i < markers.length; i++) {
-            const marker = markers[i];
-            const point = mapPointToZoomPoint(marker.mapPoint, zoom);
-            marker.pixelPosition = [point[0] - topLeft[0], point[1] - topLeft[1]];
-        }
+        bounds = {
+            minX: pixelCenter[0] - 1.5 * size.x * retinaFactor,
+            minY: pixelCenter[1] - 1.5 * size.y * retinaFactor,
+            maxX: pixelCenter[0] + 1.5 * size.x * retinaFactor,
+            maxY: pixelCenter[1] + 1.5 * size.y * retinaFactor,
+        };
 
-        if (resetLastGroupIndex) {
+        if (zoomChanged) {
             for (let i = 0; i < markers.length; i++) {
                 const marker = markers[i];
                 marker.prevGroupIndex = undefined;
                 marker.iconIndex = -1;
+                marker.pixelPosition = mapPointToZoomPoint(marker.mapPoint, zoom);
             }
-            resetLastGroupIndex = false;
+            zoomChanged = false;
         }
 
         // tslint:disable-next-line
@@ -190,7 +187,7 @@ Promise.all([
     map.on('moveend', updateGeneralization);
     map.on('zoomstart', () => {
         markerDrawer.setMarkers([]);
-        resetLastGroupIndex = true;
+        zoomChanged = true;
     });
     updateGeneralization();
 }).catch((error) => {

--- a/src/markerArray.ts
+++ b/src/markerArray.ts
@@ -15,7 +15,7 @@ export const stride = Object.keys(offsets).length;
  * Запаковывает переданный массив маркеров в типизированный массив для быстрой передачи в воркер
  */
 export function pack(markerArray: Float32Array, markers: Marker[]) {
-    for (let i = 0, markerOffset = 0; i < markers.length; i++, markerOffset = markerOffset + stride) {
+    for (let i = 0, markerOffset = 0; i < markers.length; i++, markerOffset += stride) {
         const marker = markers[i];
 
         const iconIndex = marker.iconIndex;
@@ -35,7 +35,7 @@ export function pack(markerArray: Float32Array, markers: Marker[]) {
  * Вынимает значения из запакованного типизированного массива в массив маркеров
  */
 export function unpack(markers: Marker[], markerArray: Float32Array) {
-    for (let i = 0, markerOffset = 0; i < markers.length; i++, markerOffset = markerOffset + stride) {
+    for (let i = 0, markerOffset = 0; i < markers.length; i++, markerOffset += stride) {
         const iconIndex = markerArray[markerOffset + offsets.iconIndex];
         const prevGroupIndex = markerArray[markerOffset + offsets.prevGroupIndex];
 

--- a/src/markerArray.ts
+++ b/src/markerArray.ts
@@ -1,3 +1,5 @@
+import { Marker } from './types';
+
 // Оффсеты должны быть пронумерованы по порядку
 export const offsets = {
     pixelPositionX: 0,
@@ -8,3 +10,38 @@ export const offsets = {
 };
 
 export const stride = Object.keys(offsets).length;
+
+/**
+ * Запаковывает переданный массив маркеров в типизированный массив для быстрой передачи в воркер
+ */
+export function pack(markerArray: Float32Array, markers: Marker[]) {
+    for (let i = 0, markerOffset = 0; i < markers.length; i++, markerOffset = markerOffset + stride) {
+        const marker = markers[i];
+
+        const iconIndex = marker.iconIndex;
+        const prevGroupIndex = marker.prevGroupIndex;
+
+        markerArray[markerOffset + offsets.pixelPositionX] = marker.pixelPosition[0];
+        markerArray[markerOffset + offsets.pixelPositionY] = marker.pixelPosition[1];
+        markerArray[markerOffset + offsets.groupIndex] = marker.groupIndex;
+        markerArray[markerOffset + offsets.iconIndex] =
+            iconIndex !== undefined ? iconIndex : NaN;
+        markerArray[markerOffset + offsets.prevGroupIndex] =
+            prevGroupIndex !== undefined ? prevGroupIndex : NaN;
+    }
+}
+
+/**
+ * Вынимает значения из запакованного типизированного массива в массив маркеров
+ */
+export function unpack(markers: Marker[], markerArray: Float32Array) {
+    for (let i = 0, markerOffset = 0; i < markers.length; i++, markerOffset = markerOffset + stride) {
+        const iconIndex = markerArray[markerOffset + offsets.iconIndex];
+        const prevGroupIndex = markerArray[markerOffset + offsets.prevGroupIndex];
+
+        markers[i].iconIndex =
+            iconIndex !== iconIndex ? undefined : iconIndex;
+        markers[i].prevGroupIndex =
+            prevGroupIndex !== prevGroupIndex ? undefined : prevGroupIndex;
+    }
+}

--- a/src/worker/generalize.ts
+++ b/src/worker/generalize.ts
@@ -45,9 +45,11 @@ export function generalize(data: WorkerMessage) {
 
     // Поэтому вначале закрашиваем плоскость повторно генерализуемыми маркерами
     for (let i = 0; i < markerCount; i++) {
-        const prevGroupIndex = markers[i * stride + offsets.prevGroupIndex];
-        const pixelPositionX = markers[i * stride + offsets.pixelPositionX];
-        const pixelPositionY = markers[i * stride + offsets.pixelPositionY];
+        const markerOffset = i * stride;
+
+        const prevGroupIndex = markers[markerOffset + offsets.prevGroupIndex];
+        const pixelPositionX = markers[markerOffset + offsets.pixelPositionX];
+        const pixelPositionY = markers[markerOffset + offsets.pixelPositionY];
 
         // prevGroupIndex не равен NaN, если маркер уже проходил генерализацию
         if (!isNaN(prevGroupIndex)) {
@@ -61,7 +63,17 @@ export function generalize(data: WorkerMessage) {
 
             const { size, anchor, pixelDensity } = sprite;
 
-            // Вставляем их на основную плоскость и плоскость деградции без всяких проверок
+            // Проверяем, попадает ли иконка маркера в новые границы
+            createBBox(collideBBox, width, height, pixelRatio, size, anchor, pixelDensity,
+                pixelPositionX, pixelPositionY, margin);
+
+            if (bboxIsEmpty(collideBBox)) {
+                markers[markerOffset + offsets.iconIndex] = -1;
+            } else {
+                markers[markerOffset + offsets.iconIndex] = iconIndex;
+            }
+
+            // Вставляем маркеры на основную плоскость и плоскость деградации без всяких проверок
             createBBox(marginBBox, width, height, pixelRatio, size, anchor, pixelDensity,
                 pixelPositionX, pixelPositionY, margin);
 

--- a/src/worker/generalize.ts
+++ b/src/worker/generalize.ts
@@ -8,10 +8,10 @@ const degradationBBox: BBox = { minX: 0, minY: 0, maxX: 0, maxY: 0 };
 export function generalize(data: WorkerMessage) {
     const { bounds, pixelRatio, priorityGroups, sprites, markers, markerCount } = data;
 
-    const width = (bounds.maxX - bounds.minX >> 3) + 1 << 3; // Ширина должна быть кратна 8
-    const height = bounds.maxY - bounds.minY;
+    const planeWidth = (bounds.maxX - bounds.minX >> 3) + 1 << 3; // Ширина должна быть кратна 8
+    const planeHeight = bounds.maxY - bounds.minY;
 
-    const planeLength = width * height + 8 >> 3;
+    const planeLength = planeWidth * planeHeight + 8 >> 3;
 
     /**
      * Алгоритм действует по принципу закрашивания плоскости маркерами.
@@ -48,8 +48,8 @@ export function generalize(data: WorkerMessage) {
         const markerOffset = i * stride;
 
         const prevGroupIndex = markers[markerOffset + offsets.prevGroupIndex];
-        const pixelPositionX = markers[markerOffset + offsets.pixelPositionX];
-        const pixelPositionY = markers[markerOffset + offsets.pixelPositionY];
+        const pixelPositionX = markers[markerOffset + offsets.pixelPositionX] - bounds.minX;
+        const pixelPositionY = markers[markerOffset + offsets.pixelPositionY] - bounds.minY;
 
         // prevGroupIndex не равен NaN, если маркер уже проходил генерализацию
         if (!isNaN(prevGroupIndex)) {
@@ -64,8 +64,8 @@ export function generalize(data: WorkerMessage) {
             const { size, anchor, pixelDensity } = sprite;
 
             // Проверяем, попадает ли иконка маркера в новые границы
-            createBBox(collideBBox, width, height, pixelRatio, size, anchor, pixelDensity,
-                pixelPositionX, pixelPositionY, margin);
+            createBBox(collideBBox, planeWidth, planeHeight, pixelRatio, size, anchor, pixelDensity,
+                pixelPositionX, pixelPositionY, 0);
 
             if (bboxIsEmpty(collideBBox)) {
                 markers[markerOffset + offsets.iconIndex] = -1;
@@ -74,18 +74,18 @@ export function generalize(data: WorkerMessage) {
             }
 
             // Вставляем маркеры на основную плоскость и плоскость деградации без всяких проверок
-            createBBox(marginBBox, width, height, pixelRatio, size, anchor, pixelDensity,
+            createBBox(marginBBox, planeWidth, planeHeight, pixelRatio, size, anchor, pixelDensity,
                 pixelPositionX, pixelPositionY, margin);
 
             if (!bboxIsEmpty(marginBBox)) {
-                putToArray(plane, width, marginBBox);
+                putToArray(plane, planeWidth, marginBBox);
             }
 
-            createBBox(degradationBBox, width, height, pixelRatio, size, anchor, pixelDensity,
+            createBBox(degradationBBox, planeWidth, planeHeight, pixelRatio, size, anchor, pixelDensity,
                 pixelPositionX, pixelPositionY, degradation);
 
             if (!bboxIsEmpty(degradationBBox)) {
-                putToArray(degradationPlane, width, degradationBBox);
+                putToArray(degradationPlane, planeWidth, degradationBBox);
             }
         }
     }
@@ -113,8 +113,8 @@ export function generalize(data: WorkerMessage) {
 
             const groupIndex = markers[markerOffset + offsets.groupIndex];
             const prevGroupIndex = markers[markerOffset + offsets.prevGroupIndex];
-            const pixelPositionX = markers[markerOffset + offsets.pixelPositionX];
-            const pixelPositionY = markers[markerOffset + offsets.pixelPositionY];
+            const pixelPositionX = markers[markerOffset + offsets.pixelPositionX] - bounds.minX;
+            const pixelPositionY = markers[markerOffset + offsets.pixelPositionY] - bounds.minY;
 
             // Пропускаем маркера, чей изначальный groupIndex больше индекса текущей перебираемой группы.
             // Такие маркера будут проверены в следующах группах.
@@ -124,28 +124,28 @@ export function generalize(data: WorkerMessage) {
             }
 
             // Маркер первый раз попал в область деградации – пропускаем
-            createBBox(marginBBox, width, height, pixelRatio, size, anchor, pixelDensity,
+            createBBox(marginBBox, planeWidth, planeHeight, pixelRatio, size, anchor, pixelDensity,
                 pixelPositionX, pixelPositionY, margin);
             if (bboxIsEmpty(marginBBox) ||
-                (groupIndex === i && collide(currentDegradationPlane, width, marginBBox))
+                (groupIndex === i && collide(currentDegradationPlane, planeWidth, marginBBox))
             ) {
                 continue;
             }
 
             // Область маркера пересекает область уже вставшего маркера – пропускаем
-            createBBox(collideBBox, width, height, pixelRatio, size, anchor, pixelDensity,
+            createBBox(collideBBox, planeWidth, planeHeight, pixelRatio, size, anchor, pixelDensity,
                 pixelPositionX, pixelPositionY, safeZone);
             if (bboxIsEmpty(collideBBox)) {
                 continue;
             }
 
-            if (!collide(plane, width, collideBBox)) {
-                createBBox(degradationBBox, width, height, pixelRatio, size, anchor, pixelDensity,
+            if (!collide(plane, planeWidth, collideBBox)) {
+                createBBox(degradationBBox, planeWidth, planeHeight, pixelRatio, size, anchor, pixelDensity,
                     pixelPositionX, pixelPositionY, degradation);
 
                 // Если все хорошо и маркер выжил, закрашиваем его в двух плоскостях
-                putToArray(plane, width, marginBBox);
-                putToArray(degradationPlane, width, degradationBBox);
+                putToArray(plane, planeWidth, marginBBox);
+                putToArray(degradationPlane, planeWidth, degradationBBox);
 
                 markers[markerOffset + offsets.iconIndex] = iconIndex;
                 markers[markerOffset + offsets.prevGroupIndex] = i;
@@ -238,8 +238,8 @@ function bboxIsEmpty(a: BBox): boolean {
 
 function createBBox(
     dst: BBox,
-    width: number,
-    height: number,
+    planeWidth: number,
+    planeHeight: number,
     pixelRatio: number,
     size: Vec2,
     anchor: Vec2,
@@ -257,10 +257,10 @@ function createBBox(
     const y2 = positionY * pixelRatio + size[1] * spriteScale * (1 - anchor[1]) + offset | 0;
 
     // Обрезаем область по установленным границам плоскости
-    dst.minX = x1 > 0 ? (x1 < width ? x1 : width) : 0;
-    dst.minY = y1 > 0 ? (y1 < height ? y1 : height) : 0;
-    dst.maxX = x2 > 0 ? (x2 < width ? x2 : width) : 0;
-    dst.maxY = y2 > 0 ? (y2 < height ? y2 : height) : 0;
+    dst.minX = x1 > 0 ? (x1 < planeWidth ? x1 : planeWidth) : 0;
+    dst.minY = y1 > 0 ? (y1 < planeHeight ? y1 : planeHeight) : 0;
+    dst.maxX = x2 > 0 ? (x2 < planeWidth ? x2 : planeWidth) : 0;
+    dst.maxY = y2 > 0 ? (y2 < planeHeight ? y2 : planeHeight) : 0;
 }
 
 export const testHandlers = {
@@ -269,4 +269,5 @@ export const testHandlers = {
     isNaN,
     bboxIsEmpty,
     createBBox,
+    generalize,
 };


### PR DESCRIPTION
Повторно генерализуемым маркерам нужно всё равно выставлять нужный `iconIndex`. В том числе, `iconIndex = 1` для тех маркеров, которые не попали в границы.